### PR TITLE
Fix the "search-ql" plugin after the "metarunner" plugin was renamed to "recipes"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,8 @@ ext {
     teamcityLibs = "$teamcityWebInf/lib"
     teamcityTestLibs = project.hasProperty("TeamCityTestLibs") ? TeamCityTestLibs
             : "../../.idea_artifacts/dist_openapi_integration/tests"
-    teamcityRecipePluginPath = "$teamcityWebInf/plugins/recipes.zip"
+    teamcityRecipePluginPath = project.hasProperty("TeamCityRecipesPluginPath") ? TeamCityRecipesPluginPath
+            : "../../recipes/recipes-webapp/target/teamcity/dist/recipes"
 }
 
 group 'org.example'
@@ -46,7 +47,7 @@ dependencies {
 
     provided "org.jetbrains.teamcity:server-api:$rootProject.ext.teamcityVersion"
     provided fileTree(dir: "$rootProject.ext.teamcityLibs", include: ['*.jar'])
-    provided fileTree(dir: zipTree(teamcityRecipePluginPath).find { it.name.contains('server') }, include: '*.jar')
+    provided fileTree(dir: "$rootProject.ext.teamcityRecipePluginPath/server", include: ['*.jar'])
     testImplementation fileTree(dir: "$rootProject.ext.teamcityTestLibs", include: ['*.jar'])
     testImplementation("org.testng:testng:6.8")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -12,13 +12,13 @@ ext {
     teamcityPluginVersion = project.hasProperty("PluginVersion") ? PluginVersion
             : "SNAPSHOT"
     teamcityVersion = project.hasProperty("TeamCityVersion") ? TeamCityVersion
-            : "2023.11"
+            : "2025.03-SNAPSHOT"
     teamcityWebInf = project.hasProperty("TeamCityLibs") ? TeamCityLibs
             : "../../.idea_artifacts/web-deployment/WEB-INF"
     teamcityLibs = "$teamcityWebInf/lib"
     teamcityTestLibs = project.hasProperty("TeamCityTestLibs") ? TeamCityTestLibs
             : "../../.idea_artifacts/dist_openapi_integration/tests"
-    teamcityPluginLibs = "$teamcityWebInf/plugins/metarunner/server"
+    teamcityPluginLibs = "$teamcityWebInf/plugins/recipes/server"
 }
 
 group 'org.example'
@@ -73,6 +73,7 @@ compileTestKotlin {
 
 teamcity {
     version = teamcityVersion
+    allowSnapshotVersions = true
     server {
         descriptor = file("teamcity-plugin.xml")
         tokens = [Version: teamcityPluginVersion]

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ ext {
     teamcityLibs = "$teamcityWebInf/lib"
     teamcityTestLibs = project.hasProperty("TeamCityTestLibs") ? TeamCityTestLibs
             : "../../.idea_artifacts/dist_openapi_integration/tests"
-    teamcityPluginLibs = "$teamcityWebInf/plugins/recipes/server"
+    teamcityRecipePluginPath = "$teamcityWebInf/plugins/recipes.zip"
 }
 
 group 'org.example'
@@ -46,7 +46,7 @@ dependencies {
 
     provided "org.jetbrains.teamcity:server-api:$rootProject.ext.teamcityVersion"
     provided fileTree(dir: "$rootProject.ext.teamcityLibs", include: ['*.jar'])
-    provided fileTree(dir: "$rootProject.ext.teamcityPluginLibs", include: ['*.jar'])
+    provided fileTree(dir: zipTree(teamcityRecipePluginPath).find { it.name.contains('server') }, include: '*.jar')
     testImplementation fileTree(dir: "$rootProject.ext.teamcityTestLibs", include: ['*.jar'])
     testImplementation("org.testng:testng:6.8")
 }

--- a/src/main/antlr/Keywords.g4
+++ b/src/main/antlr/Keywords.g4
@@ -15,7 +15,7 @@ import java.util.*;
         putToKeywords(BuildConfTopLevelQuery.Companion.getNames(), QLangGrammarParser.BUILD_CONFIGURATION);
         putToKeywords(TemplateTopLevelQuery.Companion.getNames(), QLangGrammarParser.TEMPLATE);
         putToKeywords(VcsRootTopLevelQuery.Companion.getNames(), QLangGrammarParser.VCS_ROOT);
-        putToKeywords(MetaRunnerTopLevelQuery.Companion.getNames(), QLangGrammarParser.META_RUNNER);
+        putToKeywords(PrivateRecipeTopLevelQuery.Companion.getNames(), QLangGrammarParser.PRIVATE_RECIPE);
 
         putToKeywords(IdFilter.Companion.getNames() , QLangGrammarParser.ID);
         putToKeywords(ArchivedFilter.Companion.getNames(), QLangGrammarParser.ARCHIVED);
@@ -53,7 +53,7 @@ import java.util.*;
 }
 
 tokens {
-       PROJECT, TEMPLATE, BUILD_CONFIGURATION, VCS_ROOT, META_RUNNER,
+       PROJECT, TEMPLATE, BUILD_CONFIGURATION, VCS_ROOT, PRIVATE_RECIPE,
        ID, PARENT, TRIGGER, STEP, FEATURE, TYPE, PARAM, VAL,
        ENABLED, ANCESTOR, RULES, DEPENDENCY, ARTIFACT, SNAPSHOT,
        WITH_INHERITED, OPTION, CLEAN, REV_RULE, VCS_ENTRY, NAME,

--- a/src/main/antlr/QLangGrammar.g4
+++ b/src/main/antlr/QLangGrammar.g4
@@ -30,7 +30,7 @@ vcsRootKeyword : VCS_ROOT;
 buildConfKeword : BUILD_CONFIGURATION ;
 projectKeword : PROJECT ;
 templateKeyword : TEMPLATE;
-metaRunnerKeyword : META_RUNNER;
+privateRecipeKeyword : PRIVATE_RECIPE;
 
 partialQuery : condition ;
 
@@ -40,7 +40,7 @@ objectKeyword : projectKeword
               | templateKeyword
               | buildConfKeword
               | vcsRootKeyword
-              | metaRunnerKeyword
+              | privateRecipeKeyword
               ;
 
 conditionInSubproject : (('in' objectId)? 'with' condition | 'in' objectId) ;

--- a/src/main/kotlin/jetbrains/buildServer/server/querylang/MyProjectManager.kt
+++ b/src/main/kotlin/jetbrains/buildServer/server/querylang/MyProjectManager.kt
@@ -1,13 +1,12 @@
 package jetbrains.buildServer.server.querylang
 
-import jetbrains.buildServer.runners.metaRunner.config.MetaRunners
+import jetbrains.buildServer.runners.recipes._private.PrivateRecipeRegistry
 import jetbrains.buildServer.serverSide.BuildTypeTemplate
 import jetbrains.buildServer.serverSide.ProjectManager
 import jetbrains.buildServer.serverSide.SBuildType
 import jetbrains.buildServer.serverSide.SProject
 import jetbrains.buildServer.vcs.SVcsRoot
 import jetbrains.buildServer.serverSide.auth.AccessDeniedException
-import jetbrains.buildServer.serverSide.auth.AuthorityHolder
 import jetbrains.buildServer.serverSide.auth.SecurityContext
 import jetbrains.buildServer.serverSide.parameters.types.ParameterTypeManager
 
@@ -49,19 +48,19 @@ class MyProjectManager(private val projectManager: ProjectManager): ProjectManag
 lateinit var myProjectManager: MyProjectManager
 lateinit var myParameterManager: ParameterTypeManager
 lateinit var mySecurityContext: SecurityContext
-lateinit var myMetaRunnersManager: MetaRunners
+lateinit var myPrivateRecipesManager: PrivateRecipeRegistry
 
 class MyProjectManagerInit(
     val projectManager: ProjectManager,
     parameterManager: ParameterTypeManager,
     securityContext: SecurityContext,
-    metaRunners: MetaRunners
+    privateRecipes: PrivateRecipeRegistry,
 ) {
     init {
         myProjectManager = MyProjectManager(projectManager)
         myParameterManager = parameterManager
         mySecurityContext = securityContext
-        myMetaRunnersManager = metaRunners
+        myPrivateRecipesManager = privateRecipes
     }
 }
 

--- a/src/main/kotlin/jetbrains/buildServer/server/querylang/ast/FilterRegistration.kt
+++ b/src/main/kotlin/jetbrains/buildServer/server/querylang/ast/FilterRegistration.kt
@@ -1,7 +1,6 @@
 package jetbrains.buildServer.server.querylang.ast
 
 import jetbrains.buildServer.server.querylang.readFromResources
-import java.io.File
 import kotlin.reflect.KClass
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.isSuperclassOf
@@ -39,7 +38,7 @@ object FilterRegistration {
         registerConditionContainer(BuildConfTopLevelQuery::class)
         registerConditionContainer(TemplateTopLevelQuery::class)
         registerConditionContainer(VcsRootTopLevelQuery::class)
-        registerConditionContainer(MetaRunnerTopLevelQuery::class)
+        registerConditionContainer(PrivateRecipeTopLevelQuery::class)
 
         registerFilter(EqualsStringFilter::class)
         registerFilter(PrefixStringFilter::class)

--- a/src/main/kotlin/jetbrains/buildServer/server/querylang/ast/MainQuery.kt
+++ b/src/main/kotlin/jetbrains/buildServer/server/querylang/ast/MainQuery.kt
@@ -181,7 +181,7 @@ data class PrivateRecipeTopLevelQuery(
     PrivateRecipeConditionContainer
 {
     companion object : ObjectDescription(
-        Names1("privateRecipe"),
+        Names1("privateRecipe", "metaRunner"),
         Descriptions(
             FixedContextDescription("search private recipes")
         )

--- a/src/main/kotlin/jetbrains/buildServer/server/querylang/ast/MainQuery.kt
+++ b/src/main/kotlin/jetbrains/buildServer/server/querylang/ast/MainQuery.kt
@@ -1,12 +1,11 @@
 package jetbrains.buildServer.server.querylang.ast
 
 import jetbrains.buildServer.server.querylang.ast.wrappers.*
-import jetbrains.buildServer.server.querylang.myMetaRunnersManager
+import jetbrains.buildServer.server.querylang.myPrivateRecipesManager
 import jetbrains.buildServer.server.querylang.myProjectManager
 import jetbrains.buildServer.server.querylang.parser.QueryParser
 import jetbrains.buildServer.server.querylang.requests.QueryResult
 import jetbrains.buildServer.server.querylang.ui.objects.*
-import jetbrains.buildServer.serverSide.impl.ProjectEx
 
 private fun checkInterruptionStatus() {
     if (Thread.currentThread().isInterrupted) {
@@ -24,7 +23,7 @@ data class FullQuery(val queries: List<TopLevelQuery<*>>): MainQuery(), Printabl
                 is BuildConfTopLevelQuery -> query.eval().objects.map { BuildConfigurationResult(it)}
                 is TemplateTopLevelQuery -> query.eval().objects.map { TemplateResult(it) }
                 is VcsRootTopLevelQuery -> query.eval().objects.map { VcsRootResult(it) }
-                is MetaRunnerTopLevelQuery -> query.eval().objects.map { MetaRunnerResult(it) }
+                is PrivateRecipeTopLevelQuery -> query.eval().objects.map { PrivateRecipeResult(it) }
             }
         }
         return QueryResult(res.toMutableList())
@@ -176,28 +175,28 @@ data class VcsRootTopLevelQuery(
     }
 }
 
-data class MetaRunnerTopLevelQuery(
-    override val condition: ConditionAST<WMetaRunner>
-) : TopLevelQuery<WMetaRunner>(),
-    MetaRunnerConditionContainer
+data class PrivateRecipeTopLevelQuery(
+    override val condition: ConditionAST<WPrivateRecipe>
+) : TopLevelQuery<WPrivateRecipe>(),
+    PrivateRecipeConditionContainer
 {
     companion object : ObjectDescription(
-        Names1("metaRunner"),
+        Names1("privateRecipe"),
         Descriptions(
-            FixedContextDescription("search meta runners")
+            FixedContextDescription("search private recipes")
         )
     )
 
     override val names = Companion.names
 
-    override fun evalFrom(condition: ConditionAST<WMetaRunner>): EvalResult<WMetaRunner> {
+    override fun evalFrom(condition: ConditionAST<WPrivateRecipe>): EvalResult<WPrivateRecipe> {
         val res = condition.eval()
 
         return if (res.filter !is NoneObjectFilter)
             EvalResult(NoneObjectFilter(),
-                myMetaRunnersManager.metaSpecs.filter {meta ->
+                myPrivateRecipesManager.recipeSpecs.filter { spec ->
                     checkInterruptionStatus()
-                    meta.configLocation.project?.valueResolver?.let { vr -> res.filter.accepts(meta.wrap(vr)) } ?: false
+                    spec.configLocation.project?.valueResolver?.let { vr -> res.filter.accepts(spec.wrap(vr)) } ?: false
                 }.mapNotNull { it.wrap(it.configLocation.project!!.valueResolver) } + res.objects
             )
         else

--- a/src/main/kotlin/jetbrains/buildServer/server/querylang/ast/commonConditionContainers.kt
+++ b/src/main/kotlin/jetbrains/buildServer/server/querylang/ast/commonConditionContainers.kt
@@ -96,8 +96,8 @@ interface VcsRootConditionContainer : ConditionContainer<WVcsRoot> {
     }
 }
 
-interface MetaRunnerConditionContainer : ConditionContainer<WMetaRunner> {
-    override fun evalFilterInner(filter: Filter<WMetaRunner>): EvalResult<WMetaRunner>? {
+interface PrivateRecipeConditionContainer : ConditionContainer<WPrivateRecipe> {
+    override fun evalFilterInner(filter: Filter<WPrivateRecipe>): EvalResult<WPrivateRecipe>? {
         return null
     }
 }

--- a/src/main/kotlin/jetbrains/buildServer/server/querylang/ast/wrappers/WPrivateRecipe.kt
+++ b/src/main/kotlin/jetbrains/buildServer/server/querylang/ast/wrappers/WPrivateRecipe.kt
@@ -1,16 +1,16 @@
 package jetbrains.buildServer.server.querylang.ast.wrappers
 
 import jetbrains.buildServer.parameters.ValueResolver
-import jetbrains.buildServer.runners.metaRunner.config.MetaSpec
+import jetbrains.buildServer.runners.recipes._private.spec.PrivateRecipeSpec
 
-fun MetaSpec.wrap(valueResolver: ValueResolver): WMetaRunner? {
+fun PrivateRecipeSpec.wrap(valueResolver: ValueResolver): WPrivateRecipe? {
     return this.configLocation.project?.let {
         if (!checkPermission(it.projectId)) null
-        else WMetaRunner(this, valueResolver)
+        else WPrivateRecipe(this, valueResolver)
     }
 }
 
-class WMetaRunner :
+class WPrivateRecipe :
     FIdContainer,
     FProjectContainer,
     FParentContainer,
@@ -18,11 +18,11 @@ class WMetaRunner :
     FNameContainer,
     FStepContainer
 {
-    private val mySpec: MetaSpec
+    private val mySpec: PrivateRecipeSpec
     private val myResolver: ValueResolver
 
-    internal constructor(metaRunner: MetaSpec, resolver: ValueResolver) {
-        mySpec = metaRunner
+    internal constructor(spec: PrivateRecipeSpec, resolver: ValueResolver) {
+        mySpec = spec
         myResolver = resolver
     }
 
@@ -63,6 +63,6 @@ class WMetaRunner :
     }
 
     override fun equals(other: Any?): Boolean {
-        return other is WMetaRunner && other.mySpec == mySpec
+        return other is WPrivateRecipe && other.mySpec == mySpec
     }
 }

--- a/src/main/kotlin/jetbrains/buildServer/server/querylang/parser/MainQueryVisitor.kt
+++ b/src/main/kotlin/jetbrains/buildServer/server/querylang/parser/MainQueryVisitor.kt
@@ -26,8 +26,8 @@ object MainQueryVisitor : QLangGrammarBaseVisitor<MainQuery>() {
                 is QLangGrammarParser.VcsRootKeywordContext -> {
                     VcsRootTopLevelQuery(ctx.conditionInSubproject().accept(ConditionVisitor(VcsRootTopLevelQuery::class)))
                 }
-                is QLangGrammarParser.MetaRunnerKeywordContext -> {
-                    MetaRunnerTopLevelQuery(ctx.conditionInSubproject().accept(ConditionVisitor(MetaRunnerTopLevelQuery::class)))
+                is QLangGrammarParser.PrivateRecipeKeywordContext -> {
+                    PrivateRecipeTopLevelQuery(ctx.conditionInSubproject().accept(ConditionVisitor(PrivateRecipeTopLevelQuery::class)))
                 }
                 else -> throw IllegalStateException("Unknown keyword in search query")
             }

--- a/src/main/kotlin/jetbrains/buildServer/server/querylang/ui/SearchAdminBean.kt
+++ b/src/main/kotlin/jetbrains/buildServer/server/querylang/ui/SearchAdminBean.kt
@@ -33,13 +33,13 @@ class SearchAdminBean(
     val resultBuildConfigurations = mutableListOf<ResultLine>()
     val resultTemplates = mutableListOf<ResultLine>()
     val resultVcsRoots = mutableListOf<ResultLine>()
-    val resultMetaRunners = mutableListOf<ResultLine>()
+    val resultPrivateRecipes = mutableListOf<ResultLine>()
 
     private val PROJECT_URL_PREFIX = "editProject.html?projectId="
     private val BUILD_CONF_URL_PREFIX = "editBuild.html?id=buildType:"
     private val BUILD_TEMPLATE_URL_PREFIX = "editBuild.html?id=template:"
     private val VCS_ROOT_URL_PREFIX = "editVcsRoot.html?vcsRootId="
-    private val META_RUNNER_URL_PREFIX = "editProject.html?tab=metaRunner&editRunnerId="
+    private val PRIVATE_RECIPE_URL_PREFIX = "editProject.html?tab=recipe&editRecipeId="
 
     fun getQuery(): String? {
         return searchAdminForm.query
@@ -57,7 +57,7 @@ class SearchAdminBean(
                 is BuildConfigurationResult -> addBuildConf(elem)
                 is TemplateResult -> addTemplate(elem)
                 is VcsRootResult -> addVcsRoot(elem)
-                is MetaRunnerResult -> addMetaRunner(elem)
+                is PrivateRecipeResult -> addPrivateRecipe(elem)
             }
         }
     }
@@ -67,7 +67,7 @@ class SearchAdminBean(
                 resultBuildConfigurations.isEmpty() &&
                 resultTemplates.isEmpty() &&
                 resultVcsRoots.isEmpty() &&
-                resultMetaRunners.isEmpty()
+                resultPrivateRecipes.isEmpty()
     }
 
     fun isWrongQuery() = wrongQueryMessage != null
@@ -82,7 +82,7 @@ class SearchAdminBean(
     fun hasBuildConfs() = resultBuildConfigurations.isNotEmpty()
     fun hasTemplates() = resultTemplates.isNotEmpty()
     fun hasVcsRoots() = resultVcsRoots.isNotEmpty()
-    fun hasMetaRunners() = resultMetaRunners.isNotEmpty()
+    fun hasPrivateRecipes() = resultPrivateRecipes.isNotEmpty()
 
     fun notAllResultsLoaded() = resultsDisplayed != resultsTotal
 
@@ -111,8 +111,8 @@ class SearchAdminBean(
         resultVcsRoots.add(getResLine(resObj, VCS_ROOT_URL_PREFIX, "&action=editVcsRoot"))
     }
 
-    private fun addMetaRunner(resObj: TeamCityObjectResult<WMetaRunner>) {
-        resultMetaRunners.add(getResLine(resObj, META_RUNNER_URL_PREFIX, "&projectId=${resObj.project?.id}"))
+    private fun addPrivateRecipe(resObj: TeamCityObjectResult<WPrivateRecipe>) {
+        resultPrivateRecipes.add(getResLine(resObj, PRIVATE_RECIPE_URL_PREFIX, "&projectId=${resObj.project?.id}"))
     }
 
     private fun getResLine(resObj: TeamCityObjectResult<*>, prefix: String, suffix: String = ""): ResultLine {

--- a/src/main/kotlin/jetbrains/buildServer/server/querylang/ui/objects/MetaRunnerResult.kt
+++ b/src/main/kotlin/jetbrains/buildServer/server/querylang/ui/objects/MetaRunnerResult.kt
@@ -1,5 +1,0 @@
-package jetbrains.buildServer.server.querylang.ui.objects
-
-import jetbrains.buildServer.server.querylang.ast.wrappers.WMetaRunner
-
-class MetaRunnerResult(conf: WMetaRunner) : TeamCityObjectResult<WMetaRunner>(conf)

--- a/src/main/kotlin/jetbrains/buildServer/server/querylang/ui/objects/PrivateRecipeResult.kt
+++ b/src/main/kotlin/jetbrains/buildServer/server/querylang/ui/objects/PrivateRecipeResult.kt
@@ -1,0 +1,5 @@
+package jetbrains.buildServer.server.querylang.ui.objects
+
+import jetbrains.buildServer.server.querylang.ast.wrappers.WPrivateRecipe
+
+class PrivateRecipeResult(conf: WPrivateRecipe) : TeamCityObjectResult<WPrivateRecipe>(conf)

--- a/src/main/resources/buildServerResources/search.jsp
+++ b/src/main/resources/buildServerResources/search.jsp
@@ -138,15 +138,15 @@
                         </ul>
                     </c:if>
 
-                    <c:if test="${searchForm.hasMetaRunners()}">
-                        <h3>Meta-Runners:</h3>
+                    <c:if test="${searchForm.hasPrivateRecipes()}">
+                        <h3>Private Recipes:</h3>
                         <ul style="list-style-type:none">
-                            <c:forEach items="${searchForm.resultMetaRunners}" var="metaRunner">
+                            <c:forEach items="${searchForm.resultPrivateRecipes}" var="privateRecipe">
                                 <li>
-                                    <a href="${metaRunner.objUrl}"><c:out value="${metaRunner.showObj}" /></a>
-                                    <c:if test="${metaRunner.parentProjectUrl != null}">
+                                    <a href="${privateRecipe.objUrl}"><c:out value="${privateRecipe.showObj}" /></a>
+                                    <c:if test="${privateRecipe.parentProjectUrl != null}">
                                         in
-                                        <a href="${metaRunner.parentProjectUrl}"><c:out value="${metaRunner.showParent}" /></a>
+                                        <a href="${privateRecipe.parentProjectUrl}"><c:out value="${privateRecipe.showParent}" /></a>
                                     </c:if>
                                 </li>
                             </c:forEach>

--- a/src/test/kotlin/jetbrains/buildServer/server/querylang/tests/BaseQueryLangTest.kt
+++ b/src/test/kotlin/jetbrains/buildServer/server/querylang/tests/BaseQueryLangTest.kt
@@ -3,8 +3,8 @@ package jetbrains.buildServer.server.querylang.tests
 import jetbrains.buildServer.artifacts.RevisionRule
 import jetbrains.buildServer.artifacts.RevisionRules
 import jetbrains.buildServer.buildTriggers.BuildTriggerDescriptor
-import jetbrains.buildServer.runners.metaRunner.config.MetaRunners
-import jetbrains.buildServer.runners.metaRunner.config.MetaSpec
+import jetbrains.buildServer.runners.recipes._private.PrivateRecipeRegistry
+import jetbrains.buildServer.runners.recipes._private.spec.PrivateRecipeSpec
 import jetbrains.buildServer.server.querylang.MyProjectManagerInit
 import jetbrains.buildServer.server.querylang.ast.FullQuery
 import jetbrains.buildServer.server.querylang.ast.NoneObjectFilter
@@ -69,7 +69,7 @@ abstract class BaseQueryLangTest : BaseServerTestCase() {
 
         eventListener = AutocompletionEventListener(taskQueue, projectManager, myFixture.eventDispatcher)
 
-        MyProjectManagerInit(projectManager, parameterTypeManager, myFixture.securityContext, MetaRunnersEmpty())
+        MyProjectManagerInit(projectManager, parameterTypeManager, myFixture.securityContext, PrivateRecipesEmpty())
 
         eventListener.serverStartup()
     }
@@ -563,16 +563,16 @@ abstract class BaseQueryLangTest : BaseServerTestCase() {
         }
     }
 
-    class MetaRunnersEmpty : MetaRunners {
-        override fun getMetaSpecs(): MutableCollection<MetaSpec> {
+    class PrivateRecipesEmpty : PrivateRecipeRegistry {
+        override fun getRecipeSpecs(): MutableCollection<PrivateRecipeSpec> {
             return mutableListOf()
         }
 
-        override fun getDeclaredSpecs(p0: SProject): MutableCollection<MetaSpec> {
+        override fun getDeclaredSpecs(p0: SProject): MutableCollection<PrivateRecipeSpec> {
             return mutableListOf()
         }
 
-        override fun findSpecByRunType(p0: SProject?, p1: String?): MetaSpec? {
+        override fun findSpecByRunType(p0: SProject?, p1: String?): PrivateRecipeSpec? {
             return null
         }
 

--- a/src/test/kotlin/jetbrains/buildServer/server/querylang/tests/autocompl/PartialQueryTests.kt
+++ b/src/test/kotlin/jetbrains/buildServer/server/querylang/tests/autocompl/PartialQueryTests.kt
@@ -21,7 +21,7 @@ class PartialQueryTests {
             "find vcsRoot with type vcsTrigger",
             "find configuration,template with vcs type vcsTrigger",
             "find project,configuration,template with feature type vcsTrigger",
-            "find configuration,template,metaRunner with step type vcsTrigger",
+            "find configuration,template,privateRecipe with step type vcsTrigger",
             "find configuration,template with trigger type vcsTrigger",
             "find project with vcsRoot type vcsTrigger"
         )
@@ -34,7 +34,7 @@ class PartialQueryTests {
 
         val res = compl.complete(query).map { it.result }
         val expected = listOf(
-            """find project,configuration,template,vcsRoot,metaRunner with param "path&1"=("Base^"* and *"ProjectResult*")"""
+            """find project,configuration,template,vcsRoot,privateRecipe with param "path&1"=("Base^"* and *"ProjectResult*")"""
         )
 
         assertEquals(expected.first(), res.first())
@@ -45,7 +45,7 @@ class PartialQueryTests {
 
         val res = compl.complete(query).map { it.result }
         val expected = listOf(
-            """find project,configuration,template,vcsRoot,metaRunner with id "Base^ProjectResult""""
+            """find project,configuration,template,vcsRoot,privateRecipe with id "Base^ProjectResult""""
         )
 
         assertEquals(expected.first(), res.first())
@@ -56,7 +56,7 @@ class PartialQueryTests {
 
         val res = compl.complete(query).map { it.result }
         val expected = listOf(
-            """find project,configuration,template,vcsRoot,metaRunner with id "Base""ProjectResult""""
+            """find project,configuration,template,vcsRoot,privateRecipe with id "Base""ProjectResult""""
         )
 
         assertEquals(expected.first(), res.first())

--- a/src/test/kotlin/jetbrains/buildServer/server/querylang/tests/client/ClientTests.kt
+++ b/src/test/kotlin/jetbrains/buildServer/server/querylang/tests/client/ClientTests.kt
@@ -1,7 +1,6 @@
 package jetbrains.buildServer.server.querylang.tests.client
 
 import jetbrains.buildServer.artifacts.RevisionRules
-import jetbrains.buildServer.runners.metaRunner.config.impl.MetaRunnersImpl
 import jetbrains.buildServer.server.querylang.MyProjectManagerInit
 import jetbrains.buildServer.server.querylang.ui.objects.BuildConfigurationResult
 import jetbrains.buildServer.server.querylang.ui.objects.ProjectResult
@@ -77,7 +76,7 @@ class ClientTests: BaseQueryLangTest() {
         p5bt1.addParameter(SimpleParameter("path", "dabacabadaba"))
         myFixture.addDependency(p5bt1, p4bt1, true)
 
-        MyProjectManagerInit(projectManager, parameterTypeManager, myFixture.securityContext, MetaRunnersEmpty())
+        MyProjectManagerInit(projectManager, parameterTypeManager, myFixture.securityContext, PrivateRecipesEmpty())
     }
 
     fun testSearchBuildConfigurationWithVcsTrigger() {

--- a/src/test/kotlin/jetbrains/buildServer/server/querylang/tests/client/PrivateRecipeQueryTest.kt
+++ b/src/test/kotlin/jetbrains/buildServer/server/querylang/tests/client/PrivateRecipeQueryTest.kt
@@ -31,7 +31,7 @@ class PrivateRecipeQueryTest : BaseQueryLangTest() {
     @DataProvider(name = "compl")
     fun complData() = TestDataProvider()
         .addComplCase(
-            "find pr",
+            "find pri",
             "privateRecipe"
         )
         .addComplCase(

--- a/src/test/kotlin/jetbrains/buildServer/server/querylang/tests/client/PrivateRecipeQueryTest.kt
+++ b/src/test/kotlin/jetbrains/buildServer/server/querylang/tests/client/PrivateRecipeQueryTest.kt
@@ -7,7 +7,7 @@ import org.testng.annotations.DataProvider
 import org.testng.annotations.Test
 import kotlin.test.assertFailsWith
 
-class MetaRunnerQueryTest : BaseQueryLangTest() {
+class PrivateRecipeQueryTest : BaseQueryLangTest() {
 
     @BeforeMethod
     override fun setUp() {
@@ -22,28 +22,28 @@ class MetaRunnerQueryTest : BaseQueryLangTest() {
 
     @DataProvider(name = "data")
     fun dataProvider() = TestDataProvider()
-        .addCase("find metaRunner with id intellij*")
-        .addCase("find metaRunner with step type ABC")
-        .addCase("find metaRunner with name Runner")
-        .addCase("find metaRunner with param path=abc")
+        .addCase("find privateRecipe with id intellij*")
+        .addCase("find privateRecipe with step type ABC")
+        .addCase("find privateRecipe with name Runner")
+        .addCase("find privateRecipe with param path=abc")
         .end()
 
     @DataProvider(name = "compl")
     fun complData() = TestDataProvider()
         .addComplCase(
             "find me",
-            "metaRunner"
+            "privateRecipe"
         )
         .addComplCase(
-            "find metaRunner with n",
+            "find privateRecipe with n",
             "name"
         )
         .addComplCase(
-            "find metaRunner with i",
+            "find privateRecipe with i",
             "id"
         )
         .addComplCase(
-            "find metaRunner with ",
+            "find privateRecipe with ",
             "id",
             "name",
             "param",

--- a/src/test/kotlin/jetbrains/buildServer/server/querylang/tests/client/PrivateRecipeQueryTest.kt
+++ b/src/test/kotlin/jetbrains/buildServer/server/querylang/tests/client/PrivateRecipeQueryTest.kt
@@ -31,7 +31,7 @@ class PrivateRecipeQueryTest : BaseQueryLangTest() {
     @DataProvider(name = "compl")
     fun complData() = TestDataProvider()
         .addComplCase(
-            "find me",
+            "find pr",
             "privateRecipe"
         )
         .addComplCase(

--- a/src/test/testng-query-lang.xml
+++ b/src/test/testng-query-lang.xml
@@ -18,7 +18,7 @@
       <class name="jetbrains.buildServer.server.querylang.tests.client.FilterTypeTests" />
       <class name="jetbrains.buildServer.server.querylang.tests.client.FilterDependencyClientTests" />
       <class name="jetbrains.buildServer.server.querylang.tests.client.FilterOptionClientTests" />
-      <class name="jetbrains.buildServer.server.querylang.tests.client.MetaRunnerQueryTest" />
+      <class name="jetbrains.buildServer.server.querylang.tests.client.PrivateRecipeQueryTest" />
       <class name="jetbrains.buildServer.server.querylang.tests.client.SearchBuildConfigurationTests" />
       <class name="jetbrains.buildServer.server.querylang.tests.client.SearchProjectTests" />
       <class name="jetbrains.buildServer.server.querylang.tests.client.SearchVcsRootTests" />

--- a/teamcity-plugin.xml
+++ b/teamcity-plugin.xml
@@ -13,6 +13,6 @@
   </info>
   <deployment use-separate-classloader="true" allow-runtime-reload="true" node-responsibilities-aware="true"/>
   <dependencies>
-    <plugin name="metarunner"/>
+    <plugin name="recipes"/>
   </dependencies>
 </teamcity-plugin>


### PR DESCRIPTION
IMPORTANT: the new version of the "search-ql" plugin will require **TeamCity 2025.03** (which is to be released).

**Description**
"metarunner" plugin has been renamed to "recipes" and two entities have been introduced "private recipes" (before "meta-runners") and "public recipes" (a new entity).

The internals of the "metarunner" plugin have also been changed: the packages, classes and methods have been renamed. All these changes are supported in this MR.